### PR TITLE
Add `cockroachdb.sqlalchemy.run_transaction` function

### DIFF
--- a/cockroachdb/sqlalchemy/__init__.py
+++ b/cockroachdb/sqlalchemy/__init__.py
@@ -1,0 +1,1 @@
+from .transaction import run_transaction  # noqa

--- a/cockroachdb/sqlalchemy/test_requirements.py
+++ b/cockroachdb/sqlalchemy/test_requirements.py
@@ -14,7 +14,8 @@ class Requirements(SuiteRequirements):
     # in the tests.
     independent_connections = exclusions.open()
 
-    # We don't support these features yet.
+    # We don't support these features yet, but the tests have them on
+    # by default.
     foreign_key_constraint_reflection = exclusions.closed()
     temporary_tables = exclusions.closed()
     temp_table_reflection = exclusions.closed()
@@ -31,19 +32,39 @@ class Requirements(SuiteRequirements):
     # The autoincrement tests assume a predictable 1-based sequence.
     autoincrement_insert = exclusions.closed()
 
-    # Turn on all the settings that are off by default but we support.
+    # The following features are off by default. We turn on as many as
+    # we can without causing test failures.
+    non_updating_cascade = exclusions.closed()
+    deferrable_fks = exclusions.closed()
     boolean_col_expressions = exclusions.open()
     nullsordering = exclusions.open()
     standalone_binds = exclusions.open()
     intersect = exclusions.open()
+    except_ = exclusions.open()
+    window_functions = exclusions.closed()
     empty_inserts = exclusions.open()
+    returning = exclusions.open()
     multivalues_inserts = exclusions.open()
     emulated_lastrowid = exclusions.open()
     dbapi_lastrowid = exclusions.open()
+    views = exclusions.closed()
+    schemas = exclusions.closed()
+    sequences = exclusions.closed()
+    sequences_optional = exclusions.closed()
+    temporary_views = exclusions.closed()
     reflects_pk_names = exclusions.open()
     unicode_ddl = exclusions.open()
+    datetime_literals = exclusions.closed()
     datetime_historic = exclusions.open()
     date_historic = exclusions.open()
+    precision_numerics_enotation_small = exclusions.open()
+    precision_numerics_enotation_large = exclusions.open()
+    precision_numerics_many_significant_digits = exclusions.closed()
+    precision_numerics_retains_significant_digits = exclusions.open()
+    savepoints = exclusions.closed()
+    two_phase_transactions = exclusions.closed()
     update_from = exclusions.open()
     mod_operator_as_percent_sign = exclusions.open()
+    # The psycopg driver doesn't support these.
+    percent_schema_names = exclusions.closed()
     order_by_label_with_expression = exclusions.open()

--- a/cockroachdb/sqlalchemy/transaction.py
+++ b/cockroachdb/sqlalchemy/transaction.py
@@ -1,25 +1,80 @@
 import psycopg2
+import sqlalchemy.engine
 import sqlalchemy.exc
+import sqlalchemy.orm
+
+from .dialect import savepoint_state
 
 
-def run_transaction(conn, func):
-    """Run a transaction on the given connection.
+def run_transaction(transactor, callback):
+    """Run a transaction with retries.
 
-    ``func()`` will be called with one argument (the connection) to
-    execute the transaction. ``func`` may be called more than once; it
-    should have no side effects other than writes to the database on
-    the given connection.
+    ``callback()`` will be called with one argument to execute the
+    transaction. ``callback`` may be called more than once; it should have
+    no side effects other than writes to the database on the given
+    connection. ``callback`` should not call ``commit()` or ``rollback()``;
+    these will be called automatically.
+
+    The ``transactor`` argument may be one of the following types:
+    * `sqlalchemy.engine.Connection`: the same connection is passed to the callback.
+    * `sqlalchemy.engine.Engine`: a connection is created and passed to the callback.
+    * `sqlalchemy.orm.sessionmaker`: a session is created and passed to the callback.
+    """
+    if isinstance(transactor, sqlalchemy.engine.Connection):
+        return _txn_retry_loop(transactor, callback)
+    elif isinstance(transactor, sqlalchemy.engine.Engine):
+        with transactor.connect() as connection:
+            return _txn_retry_loop(connection, callback)
+    elif isinstance(transactor, sqlalchemy.orm.sessionmaker):
+        session = transactor(autocommit=True)
+        return _txn_retry_loop(session, callback)
+    else:
+        raise TypeError("don't know how to run a transaction on %s", type(transactor))
+
+
+class _NestedTransaction(object):
+    """Wraps begin_nested() to set the savepoint_state thread-local.
+
+    This causes the savepoint statements that are a part of this retry
+    loop to be rewritten by the dialect.
+    """
+    def __init__(self, conn):
+        self.conn = conn
+
+    def __enter__(self):
+        try:
+            savepoint_state.cockroach_restart = True
+            self.txn = self.conn.begin_nested()
+            if isinstance(self.conn, sqlalchemy.orm.Session):
+                # Sessions are lazy and don't execute the savepoint
+                # query until you ask for the connection.
+                self.conn.connection()
+        finally:
+            savepoint_state.cockroach_restart = False
+        return self
+
+    def __exit__(self, typ, value, tb):
+        try:
+            savepoint_state.cockroach_restart = True
+            self.txn.__exit__(typ, value, tb)
+        finally:
+            savepoint_state.cockroach_restart = False
+
+
+def _txn_retry_loop(conn, callback):
+    """Inner transaction retry loop.
+
+    ``conn`` may be either a Connection or a Session, but they both
+    have compatible ``begin()`` and ``begin_nested()`` methods.
     """
     with conn.begin():
         while True:
-            conn.execute("SAVEPOINT cockroach_restart")
             try:
-                ret = func(conn)
-                conn.execute("RELEASE SAVEPOINT cockroach_restart")
-                return ret
+                with _NestedTransaction(conn):
+                    ret = callback(conn)
+                    return ret
             except sqlalchemy.exc.DatabaseError as e:
                 if isinstance(e.orig, psycopg2.DatabaseError):
                     if e.orig.pgcode == 'CR000':
-                        conn.execute("ROLLBACK TO SAVEPOINT cockroach_restart")
                         continue
                 raise

--- a/cockroachdb/sqlalchemy/transaction.py
+++ b/cockroachdb/sqlalchemy/transaction.py
@@ -1,0 +1,25 @@
+import psycopg2
+import sqlalchemy.exc
+
+
+def run_transaction(conn, func):
+    """Run a transaction on the given connection.
+
+    ``func()`` will be called with one argument (the connection) to
+    execute the transaction. ``func`` may be called more than once; it
+    should have no side effects other than writes to the database on
+    the given connection.
+    """
+    with conn.begin():
+        while True:
+            conn.execute("SAVEPOINT cockroach_restart")
+            try:
+                ret = func(conn)
+                conn.execute("RELEASE SAVEPOINT cockroach_restart")
+                return ret
+            except sqlalchemy.exc.DatabaseError as e:
+                if isinstance(e.orig, psycopg2.DatabaseError):
+                    if e.orig.pgcode == 'CR000':
+                        conn.execute("ROLLBACK TO SAVEPOINT cockroach_restart")
+                        continue
+                raise

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,10 +4,11 @@
 # To add/update dependencies, update test-requirements.txt.in (not the
 # generated test-requirements.txt) and run make update-requirements
 
-pytest==2.9.1
+SQLAlchemy==1.0.13
 mock==2.0.0
+pytest==2.9.1
+futures==3.0.5
 ## The following requirements were added by pip freeze:
 pbr==1.9.1
 py==1.4.31
 six==1.10.0
-SQLAlchemy==1.0.13

--- a/test-requirements.txt.in
+++ b/test-requirements.txt.in
@@ -7,3 +7,4 @@
 SQLAlchemy
 mock
 pytest
+futures

--- a/test/sqlalchemy/test_run_transaction.py
+++ b/test/sqlalchemy/test_run_transaction.py
@@ -1,0 +1,79 @@
+from concurrent.futures import ThreadPoolExecutor
+from sqlalchemy import Table, Column, MetaData, select, testing
+from sqlalchemy.testing import fixtures
+from sqlalchemy.types import Integer
+import threading
+
+from cockroachdb.sqlalchemy import run_transaction
+
+
+class RunTransactionTest(fixtures.TestBase):
+    def setup_method(self, method):
+        self.meta = MetaData(testing.db)
+        self.tbl = Table('t', self.meta,
+                         Column('acct', Integer, primary_key=True, autoincrement=False),
+                         Column('balance', Integer))
+        self.meta.create_all()
+        testing.db.execute(self.tbl.insert(), [dict(acct=1, balance=100),
+                                               dict(acct=2, balance=100)])
+
+    def teardown_method(self, method):
+        self.meta.drop_all()
+
+    def test_run_transaction(self):
+        def get_balances(conn):
+            result = []
+            query = (select([self.tbl.c.balance])
+                     .where(self.tbl.c.acct.in_((1, 2)))
+                     .order_by(self.tbl.c.acct))
+            for row in conn.execute(query):
+                result.append(row.balance)
+            if len(result) != 2:
+                raise Exception("Expected two balances; got %d", len(result))
+            return result
+
+        cv = threading.Condition()
+        wait_count = [2]
+
+        def worker():
+            iters = [0]
+
+            def txn_body(conn):
+                balances = get_balances(conn)
+
+                iters[0] += 1
+                if iters[0] == 1:
+                    # If this is the first iteration, wait for the other txn to also read.
+                    with cv:
+                        wait_count[0] -= 1
+                        cv.notifyAll()
+                        while wait_count[0] > 0:
+                            cv.wait()
+
+                # Now, subtract from one account and give to the other.
+                if balances[0] > balances[1]:
+                    conn.execute(self.tbl.update().where(self.tbl.c.acct == 1)
+                                 .values(balance=self.tbl.c.balance-100))
+                    conn.execute(self.tbl.update().where(self.tbl.c.acct == 2)
+                                 .values(balance=self.tbl.c.balance+100))
+                else:
+                    conn.execute(self.tbl.update().where(self.tbl.c.acct == 1)
+                                 .values(balance=self.tbl.c.balance+100))
+                    conn.execute(self.tbl.update().where(self.tbl.c.acct == 2)
+                                 .values(balance=self.tbl.c.balance-100))
+            with testing.db.connect() as conn:
+                run_transaction(conn, txn_body)
+            return iters[0]
+
+        with ThreadPoolExecutor(2) as executor:
+            future1 = executor.submit(worker)
+            future2 = executor.submit(worker)
+            iters1 = future1.result()
+            iters2 = future2.result()
+
+        assert iters1 + iters2 > 2, ("expected at least one retry between the competing "
+                                     "txns, got txn1=%d, txn2=%d" % (iters1, iters2))
+
+        balances = get_balances(testing.db)
+        assert balances == [100, 100], ("expected balances to be restored without error; "
+                                        "got %s" % balances)

--- a/test/sqlalchemy/test_run_transaction.py
+++ b/test/sqlalchemy/test_run_transaction.py
@@ -1,46 +1,62 @@
 from concurrent.futures import ThreadPoolExecutor
 from sqlalchemy import Table, Column, MetaData, select, testing
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
 from sqlalchemy.testing import fixtures
 from sqlalchemy.types import Integer
 import threading
 
 from cockroachdb.sqlalchemy import run_transaction
 
+meta = MetaData()
 
-class RunTransactionTest(fixtures.TestBase):
+# Plain table object for the core test.
+account_table = Table('account', meta,
+                      Column('acct', Integer, primary_key=True, autoincrement=False),
+                      Column('balance', Integer))
+
+
+# ORM class for the session test.
+class Account(declarative_base()):
+    __table__ = account_table
+
+
+class BaseRunTransactionTest(fixtures.TestBase):
     def setup_method(self, method):
-        self.meta = MetaData(testing.db)
-        self.tbl = Table('t', self.meta,
-                         Column('acct', Integer, primary_key=True, autoincrement=False),
-                         Column('balance', Integer))
-        self.meta.create_all()
-        testing.db.execute(self.tbl.insert(), [dict(acct=1, balance=100),
-                                               dict(acct=2, balance=100)])
+        meta.create_all(testing.db)
+        testing.db.execute(account_table.insert(), [dict(acct=1, balance=100),
+                                                    dict(acct=2, balance=100)])
 
     def teardown_method(self, method):
-        self.meta.drop_all()
+        meta.drop_all(testing.db)
 
-    def test_run_transaction(self):
-        def get_balances(conn):
-            result = []
-            query = (select([self.tbl.c.balance])
-                     .where(self.tbl.c.acct.in_((1, 2)))
-                     .order_by(self.tbl.c.acct))
-            for row in conn.execute(query):
-                result.append(row.balance)
-            if len(result) != 2:
-                raise Exception("Expected two balances; got %d", len(result))
-            return result
+    def get_balances(self, conn):
+        """Returns the balances of the two accounts as a list."""
+        result = []
+        query = (select([account_table.c.balance])
+                 .where(account_table.c.acct.in_((1, 2)))
+                 .order_by(account_table.c.acct))
+        for row in conn.execute(query):
+            result.append(row.balance)
+        if len(result) != 2:
+            raise Exception("Expected two balances; got %d", len(result))
+        return result
 
+    def run_parallel_transactions(self, callback):
+        """Runs the callback in two parallel transactions.
+
+        A barrier function is passed to the callback and should be run
+        after the transaction has performed its first read. This
+        synchronizes the two transactions to ensure that at least one
+        of them must restart.
+        """
         cv = threading.Condition()
         wait_count = [2]
 
         def worker():
             iters = [0]
 
-            def txn_body(conn):
-                balances = get_balances(conn)
-
+            def barrier():
                 iters[0] += 1
                 if iters[0] == 1:
                     # If this is the first iteration, wait for the other txn to also read.
@@ -50,19 +66,7 @@ class RunTransactionTest(fixtures.TestBase):
                         while wait_count[0] > 0:
                             cv.wait()
 
-                # Now, subtract from one account and give to the other.
-                if balances[0] > balances[1]:
-                    conn.execute(self.tbl.update().where(self.tbl.c.acct == 1)
-                                 .values(balance=self.tbl.c.balance-100))
-                    conn.execute(self.tbl.update().where(self.tbl.c.acct == 2)
-                                 .values(balance=self.tbl.c.balance+100))
-                else:
-                    conn.execute(self.tbl.update().where(self.tbl.c.acct == 1)
-                                 .values(balance=self.tbl.c.balance+100))
-                    conn.execute(self.tbl.update().where(self.tbl.c.acct == 2)
-                                 .values(balance=self.tbl.c.balance-100))
-            with testing.db.connect() as conn:
-                run_transaction(conn, txn_body)
+            callback(barrier)
             return iters[0]
 
         with ThreadPoolExecutor(2) as executor:
@@ -73,7 +77,50 @@ class RunTransactionTest(fixtures.TestBase):
 
         assert iters1 + iters2 > 2, ("expected at least one retry between the competing "
                                      "txns, got txn1=%d, txn2=%d" % (iters1, iters2))
-
-        balances = get_balances(testing.db)
+        balances = self.get_balances(testing.db)
         assert balances == [100, 100], ("expected balances to be restored without error; "
                                         "got %s" % balances)
+
+
+class RunTransactionCoreTest(BaseRunTransactionTest):
+    def perform_transfer(self, conn, balances):
+        if balances[0] > balances[1]:
+            conn.execute(account_table.update().where(account_table.c.acct == 1)
+                         .values(balance=account_table.c.balance-100))
+            conn.execute(account_table.update().where(account_table.c.acct == 2)
+                         .values(balance=account_table.c.balance+100))
+        else:
+            conn.execute(account_table.update().where(account_table.c.acct == 1)
+                         .values(balance=account_table.c.balance+100))
+            conn.execute(account_table.update().where(account_table.c.acct == 2)
+                         .values(balance=account_table.c.balance-100))
+
+    def test_run_transaction(self):
+        def callback(barrier):
+            def txn_body(conn):
+                balances = self.get_balances(conn)
+                barrier()
+                self.perform_transfer(conn, balances)
+            with testing.db.connect() as conn:
+                run_transaction(conn, txn_body)
+        self.run_parallel_transactions(callback)
+
+
+class RunTransactionSessionTest(BaseRunTransactionTest):
+    def test_run_transaction(self):
+        def callback(barrier):
+            Session = sessionmaker(testing.db)
+
+            def txn_body(session):
+                accounts = list(session.query(Account)
+                                .filter(Account.acct.in_((1, 2)))
+                                .order_by(Account.acct))
+                barrier()
+                if accounts[0].balance > accounts[1].balance:
+                    accounts[0].balance -= 100
+                    accounts[1].balance += 100
+                else:
+                    accounts[0].balance += 100
+                    accounts[1].balance -= 100
+            run_transaction(Session, txn_body)
+        self.run_parallel_transactions(callback)

--- a/test/sqlalchemy/test_suite.py
+++ b/test/sqlalchemy/test_suite.py
@@ -1,14 +1,1 @@
 from sqlalchemy.testing.suite import *  # noqa
-
-from sqlalchemy.testing.suite import RowFetchTest as _RowFetchTest
-
-
-# This test isn't controllable with any requirements setting,
-# so patch it out by hand. The failure relates to the fact that
-# we return time zone offsets on timestamps that are not configured
-# as "WITH TIME ZONE".
-class RowFetchTest(_RowFetchTest):
-    def test_row_w_scalar_select(self):
-        pass
-
-del _RowFetchTest

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,9 @@
 envlist = py27,py35
 
 [testenv]
+# Run a single test with e.g. tox -e py35 test/sqlalchemy/test_run_transaction.py
 commands =
-     py.test -p sqlalchemy.testing.plugin.pytestplugin test/sqlalchemy
+     py.test -p sqlalchemy.testing.plugin.pytestplugin {posargs:test/sqlalchemy}
 deps = --requirement=test-requirements.txt
 # For some reason pip fails to load the requirements file without this.
 setenv = LANG=en_US.utf-8


### PR DESCRIPTION
This implements cockroachdb's transaction restart error handling. The code and test is translated from `cockroachdb/cockroach-go`. The test currently fails about one in ten times; see cockroachdb/cockroach#6836.