### PR TITLE
Misc updates

### DIFF
--- a/build/circle-deps.sh
+++ b/build/circle-deps.sh
@@ -4,7 +4,7 @@ set -eux -o pipefail
 
 pip install -r dev-requirements.txt
 
-COCKROACH_VERSION=beta-20160519
+COCKROACH_VERSION=beta-20170112
 COCKROACH_PLATFORM=linux-amd64
 COCKROACH_NAME=cockroach-${COCKROACH_VERSION}.${COCKROACH_PLATFORM}
 DOWNLOAD_DIR=~/cockroach-download

--- a/cockroachdb/sqlalchemy/ddl_compiler.py
+++ b/cockroachdb/sqlalchemy/ddl_compiler.py
@@ -2,27 +2,9 @@ from sqlalchemy.dialects.postgresql.base import PGDDLCompiler
 
 
 class DDLCompiler(PGDDLCompiler):
-    def get_column_specification(self, column, **kwargs):
-        # Same as superclass version but replaces SERIAL with
-        # unique_rowid.
-        colspec = self.preparer.format_column(column)
-        default = None
-        if column.primary_key and \
-           column is column.table._autoincrement_column:
-            colspec += " INTEGER"
-            default = "unique_rowid()"
-        else:
-            colspec += " " + self.dialect.type_compiler.process(
-                column.type, type_expression=column)
-            default = self.get_column_default_string(column)
-        if default is not None:
-            colspec += " DEFAULT " + default
-
-        if not column.nullable:
-            colspec += " NOT NULL"
-        return colspec
-
     def visit_foreign_key_constraint(self, constraint):
-        # Drop all foreign key constraints because we don't support
-        # them yet.
+        # Drop all foreign key constraints. We support them now but at
+        # least one test fails with them enabled because we don't
+        # support dropping tables with self-referential foreign keys
+        # (#12916)
         return None

--- a/cockroachdb/sqlalchemy/dialect.py
+++ b/cockroachdb/sqlalchemy/dialect.py
@@ -48,6 +48,8 @@ class _SavepointState(threading.local):
     """
     def __init__(self):
         self.cockroach_restart = False
+
+
 savepoint_state = _SavepointState()
 
 

--- a/cockroachdb/sqlalchemy/dialect.py
+++ b/cockroachdb/sqlalchemy/dialect.py
@@ -82,14 +82,16 @@ class CockroachDBDialect(PGDialect_psycopg2):
         # used.
         return (9, 5, 0)
 
-    def _get_default_schema_name(self, conn):
-        raise NotImplementedError()
-
     def get_table_names(self, conn, schema=None, **kw):
+        # Upstream implementation needs correlated subqueries.
         return [row.Table for row in conn.execute("SHOW TABLES")]
 
     def has_table(self, conn, table, schema=None):
+        # Upstream implementation needs pg_table_is_visible().
         return any(t == table for t in self.get_table_names(conn, schema=schema))
+
+    # The upstream implementations of the reflection functions below depend on
+    # get_table_oid() which needs pg_table_is_visible().
 
     def get_columns(self, conn, table_name, schema=None, **kw):
         res = []
@@ -151,18 +153,21 @@ class CockroachDBDialect(PGDialect_psycopg2):
         return res
 
     def do_savepoint(self, connection, name):
+        # Savepoint logic customized to work with run_transaction().
         if savepoint_state.cockroach_restart:
             connection.execute('SAVEPOINT cockroach_restart')
         else:
             super(CockroachDBDialect, self).do_savepoint(connection, name)
 
     def do_rollback_to_savepoint(self, connection, name):
+        # Savepoint logic customized to work with run_transaction().
         if savepoint_state.cockroach_restart:
             connection.execute('ROLLBACK TO SAVEPOINT cockroach_restart')
         else:
             super(CockroachDBDialect, self).do_rollback_to_savepoint(connection, name)
 
     def do_release_savepoint(self, connection, name):
+        # Savepoint logic customized to work with run_transaction().
         if savepoint_state.cockroach_restart:
             connection.execute('RELEASE SAVEPOINT cockroach_restart')
         else:

--- a/cockroachdb/sqlalchemy/dialect.py
+++ b/cockroachdb/sqlalchemy/dialect.py
@@ -115,6 +115,9 @@ class CockroachDBDialect(PGDialect_psycopg2):
         columns = collections.defaultdict(list)
         # TODO(bdarnell): escape table name
         for row in conn.execute('SHOW INDEXES FROM "%s"' % table_name):
+            # beta-20170112 and older versions do not have the Implicit column.
+            if getattr(row, "Implicit", False):
+                continue
             columns[row.Name].append(row.Column)
             uniques[row.Name] = row.Unique
         res = []

--- a/cockroachdb/sqlalchemy/test_requirements.py
+++ b/cockroachdb/sqlalchemy/test_requirements.py
@@ -16,7 +16,6 @@ class Requirements(SuiteRequirements):
 
     # We don't support these features yet, but the tests have them on
     # by default.
-    foreign_key_constraint_reflection = exclusions.closed()
     temporary_tables = exclusions.closed()
     temp_table_reflection = exclusions.closed()
     time = exclusions.closed()
@@ -27,28 +26,33 @@ class Requirements(SuiteRequirements):
     date_coerces_from_datetime = exclusions.closed()
 
     # Our reflection support is incomplete (we need to return type
-    # parameters and hide the implicit rowid index).
+    # parameters).
     table_reflection = exclusions.closed()
+    # The following tests are also disabled by disabling_table_reflection,
+    # but are failing for their own reasons.
+    view_reflection = exclusions.closed()
+    view_column_reflection = exclusions.closed()
+    foreign_key_constraint_reflection = exclusions.closed()
 
     # The autoincrement tests assume a predictable 1-based sequence.
     autoincrement_insert = exclusions.closed()
 
     # The following features are off by default. We turn on as many as
     # we can without causing test failures.
-    non_updating_cascade = exclusions.closed()
+    non_updating_cascade = exclusions.open()
     deferrable_fks = exclusions.closed()
     boolean_col_expressions = exclusions.open()
     nullsordering = exclusions.open()
     standalone_binds = exclusions.open()
     intersect = exclusions.open()
     except_ = exclusions.open()
-    window_functions = exclusions.closed()
+    window_functions = exclusions.open()
     empty_inserts = exclusions.open()
     returning = exclusions.open()
     multivalues_inserts = exclusions.open()
     emulated_lastrowid = exclusions.open()
     dbapi_lastrowid = exclusions.open()
-    views = exclusions.closed()
+    views = exclusions.open()
     schemas = exclusions.closed()
     sequences = exclusions.closed()
     sequences_optional = exclusions.closed()

--- a/cockroachdb/sqlalchemy/test_requirements.py
+++ b/cockroachdb/sqlalchemy/test_requirements.py
@@ -21,6 +21,7 @@ class Requirements(SuiteRequirements):
     temp_table_reflection = exclusions.closed()
     time = exclusions.closed()
     time_microseconds = exclusions.closed()
+    server_side_cursors = exclusions.closed()
 
     # We don't do implicit casts.
     date_coerces_from_datetime = exclusions.closed()

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,18 +4,19 @@
 # generated dev-requirements.txt), run make update-requirements,
 # then re-run bootstrap.sh.
 
-flake8==2.5.4
-tox==2.3.1
-
+flake8==3.2.1
+tox==2.5.0
 # Twine is used in the release process to upload the package.
-twine==1.6.5
+twine==1.8.1
 ## The following requirements were added by pip freeze:
-mccabe==0.4.0
-pep8==1.7.0
-pkginfo==1.2.1
-pluggy==0.3.1
-py==1.4.31
-pyflakes==1.0.0
-requests==2.10.0
-requests-toolbelt==0.6.2
-virtualenv==15.0.1
+args==0.1.0
+clint==0.5.1
+mccabe==0.5.3
+pkginfo==1.4.1
+pluggy==0.4.0
+py==1.4.32
+pycodestyle==2.2.0
+pyflakes==1.3.0
+requests==2.12.4
+requests-toolbelt==0.7.0
+virtualenv==15.1.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,11 +4,11 @@
 # To add/update dependencies, update test-requirements.txt.in (not the
 # generated test-requirements.txt) and run make update-requirements
 
-SQLAlchemy==1.0.13
+SQLAlchemy==1.1.4
 mock==2.0.0
-pytest==2.9.1
+pytest==3.0.5
 futures==3.0.5
 ## The following requirements were added by pip freeze:
-pbr==1.9.1
-py==1.4.31
+pbr==1.10.0
+py==1.4.32
 six==1.10.0


### PR DESCRIPTION
Update the sqlalchemy dialect for cockroachdb/cockroach#12801. 
Remove some customization that is no longer necessary, and document what else is missing.
Enable more tests now that we have more features and are closer to postgres compatibility.
Update dependencies. 