### PR TITLE
Fix get_columns, implement type parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ MANIFEST
 
 # pytest cache
 .cache
+
+# created by release process
+dist/

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ all: test
 test:
 	tox
 
-.PHONY: check
-check:
+.PHONY: lint
+lint:
 	flake8 --max-line-length=100 cockroachdb test
 	python setup.py check
 

--- a/build/circle-deps.sh
+++ b/build/circle-deps.sh
@@ -4,7 +4,7 @@ set -eux -o pipefail
 
 pip install -r dev-requirements.txt
 
-COCKROACH_VERSION=beta-20170112
+COCKROACH_VERSION=v1.0.1
 COCKROACH_PLATFORM=linux-amd64
 COCKROACH_NAME=cockroach-${COCKROACH_VERSION}.${COCKROACH_PLATFORM}
 DOWNLOAD_DIR=~/cockroach-download

--- a/build/circle-test.sh
+++ b/build/circle-test.sh
@@ -6,4 +6,4 @@ bin/cockroach start --background
 bin/cockroach sql -e 'CREATE DATABASE IF NOT EXISTS test_sqlalchemy'
 
 make test
-make check
+make lint

--- a/build/circle-test.sh
+++ b/build/circle-test.sh
@@ -2,8 +2,8 @@
 
 set -eux -o pipefail
 
-bin/cockroach start --background
-bin/cockroach sql -e 'CREATE DATABASE IF NOT EXISTS test_sqlalchemy'
+bin/cockroach start --background --insecure
+bin/cockroach sql --insecure -e 'CREATE DATABASE IF NOT EXISTS test_sqlalchemy'
 
 make test
 make lint

--- a/cockroachdb/sqlalchemy/dialect.py
+++ b/cockroachdb/sqlalchemy/dialect.py
@@ -97,7 +97,7 @@ class CockroachDBDialect(PGDialect_psycopg2):
         res = []
         # TODO(bdarnell): escape table name
         for row in conn.execute('SHOW COLUMNS FROM "%s"' % table_name):
-            name, type_name, nullable, default = row
+            name, type_name, nullable, default = row[:4]
             # TODO(bdarnell): when there are type parameters, attach
             # them to the returned type object.
             try:

--- a/cockroachdb/sqlalchemy/dialect.py
+++ b/cockroachdb/sqlalchemy/dialect.py
@@ -1,4 +1,5 @@
 import collections
+import re
 import threading
 from sqlalchemy.dialects.postgresql.base import PGDialect
 from sqlalchemy.dialects.postgresql.psycopg2 import PGDialect_psycopg2
@@ -97,14 +98,25 @@ class CockroachDBDialect(PGDialect_psycopg2):
         res = []
         # TODO(bdarnell): escape table name
         for row in conn.execute('SHOW COLUMNS FROM "%s"' % table_name):
-            name, type_name, nullable, default = row[:4]
-            # TODO(bdarnell): when there are type parameters, attach
-            # them to the returned type object.
-            try:
-                typ = _type_map[type_name.split('(')[0].lower()]
-            except KeyError:
-                warn("Did not recognize type '%s' of column '%s'" % (type_name, name))
-                typ = sqltypes.NULLTYPE
+            name, type_str, nullable, default = row[:4]
+            # When there are type parameters, attach them to the
+            # returned type object.
+            m = re.match(r'^(\w+)(?:\(([0-9, ]*)\))?$', type_str)
+            if m is None:
+                warn("Could not parse type name '%s'" % type_str)
+                typ = sqltypes.NULLTYPE()
+            else:
+                type_name, type_args = m.groups()
+                try:
+                    type_class = _type_map[type_name.lower()]
+                except KeyError:
+                    warn("Did not recognize type '%s' of column '%s'" %
+                         (type_name, name))
+                    type_class = sqltypes.NULLTYPE
+                if type_args:
+                    typ = type_class(*[int(s.strip()) for s in type_args.split(',')])
+                else:
+                    typ = type_class()
             res.append(dict(
                 name=name,
                 type=typ,

--- a/cockroachdb/sqlalchemy/test_requirements.py
+++ b/cockroachdb/sqlalchemy/test_requirements.py
@@ -27,7 +27,7 @@ class Requirements(SuiteRequirements):
 
     # Our reflection support is incomplete (we need to return type
     # parameters).
-    table_reflection = exclusions.closed()
+    table_reflection = exclusions.open()
     # The following tests are also disabled by disabling_table_reflection,
     # but are failing for their own reasons.
     view_reflection = exclusions.closed()

--- a/cockroachdb/sqlalchemy/test_requirements.py
+++ b/cockroachdb/sqlalchemy/test_requirements.py
@@ -25,13 +25,12 @@ class Requirements(SuiteRequirements):
     # We don't do implicit casts.
     date_coerces_from_datetime = exclusions.closed()
 
-    # Our reflection support is incomplete (we need to return type
-    # parameters).
-    table_reflection = exclusions.open()
-    # The following tests are also disabled by disabling_table_reflection,
-    # but are failing for their own reasons.
+    # We do not support creation of views with `SELECT *` expressions,
+    # which these tests use.
     view_reflection = exclusions.closed()
     view_column_reflection = exclusions.closed()
+    # Requires either implementing pg_get_constraintdef() or overriding
+    # Dialect.get_foreign_keys()
     foreign_key_constraint_reflection = exclusions.closed()
 
     # The autoincrement tests assume a predictable 1-based sequence.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,19 +4,22 @@
 # generated dev-requirements.txt), run make update-requirements,
 # then re-run bootstrap.sh.
 
-flake8==3.2.1
-tox==2.5.0
+flake8==3.3.0
+tox==2.7.0
 # Twine is used in the release process to upload the package.
-twine==1.8.1
+twine==1.9.1
 ## The following requirements were added by pip freeze:
-args==0.1.0
-clint==0.5.1
-mccabe==0.5.3
+certifi==2017.4.17
+chardet==3.0.4
+idna==2.5
+mccabe==0.6.1
 pkginfo==1.4.1
 pluggy==0.4.0
-py==1.4.32
-pycodestyle==2.2.0
-pyflakes==1.3.0
-requests==2.12.4
-requests-toolbelt==0.7.0
+py==1.4.34
+pycodestyle==2.3.1
+pyflakes==1.5.0
+requests==2.17.3
+requests-toolbelt==0.8.0
+tqdm==4.14.0
+urllib3==1.21.1
 virtualenv==15.1.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,11 +4,11 @@
 # To add/update dependencies, update test-requirements.txt.in (not the
 # generated test-requirements.txt) and run make update-requirements
 
-SQLAlchemy==1.1.4
+SQLAlchemy==1.1.10
 mock==2.0.0
-pytest==3.0.5
-futures==3.0.5
+pytest==3.1.2
+futures==3.1.1
 ## The following requirements were added by pip freeze:
-pbr==1.10.0
-py==1.4.32
+pbr==3.0.1
+py==1.4.34
 six==1.10.0


### PR DESCRIPTION
`get_columns()` has been broken since january, but the tests that could have detected the breakage were skipped because we had not yet implemented type parameters. Fix both issues. 