### PR TITLE
Stub out get_foreign_keys

### DIFF
--- a/cockroachdb/sqlalchemy/dialect.py
+++ b/cockroachdb/sqlalchemy/dialect.py
@@ -164,6 +164,14 @@ class CockroachDBDialect(PGDialect_psycopg2):
                 res.append(index)
         return res
 
+    def get_foreign_keys(self, conn, table_name, schema=None, **kw):
+        # TODO(bdarnell): The postgres dialect implementation depends
+        # on pg_get_constraintdef, which we don't support. We need to
+        # implement that function or provide our own implementation of
+        # get_foreign_keys() in terms of our SHOW CONSTRAINTS command.
+        # For now, just return nothing.
+        return []
+
     def do_savepoint(self, connection, name):
         # Savepoint logic customized to work with run_transaction().
         if savepoint_state.cockroach_restart:

--- a/cockroachdb/sqlalchemy/dialect.py
+++ b/cockroachdb/sqlalchemy/dialect.py
@@ -172,6 +172,12 @@ class CockroachDBDialect(PGDialect_psycopg2):
         # For now, just return nothing.
         return []
 
+    def get_check_constraints(self, conn, table_name, schema=None, **kw):
+        # TODO(bdarnell): The postgres dialect implementation depends on
+        # pg_table_is_visible, which is supported in cockroachdb 1.1
+        # but not in 1.0. Figure out a versioning strategy.
+        return []
+
     def do_savepoint(self, connection, name):
         # Savepoint logic customized to work with run_transaction().
         if savepoint_state.cockroach_restart:

--- a/test/sqlalchemy/test_introspection.py
+++ b/test/sqlalchemy/test_introspection.py
@@ -1,0 +1,37 @@
+from sqlalchemy import Table, Column, MetaData, testing, ForeignKey, UniqueConstraint, \
+    CheckConstraint
+from sqlalchemy.types import Integer, String
+from sqlalchemy.testing import fixtures
+
+meta = MetaData()
+
+customer_table = Table('customer', meta,
+                       Column('id', Integer, primary_key=True),
+                       Column('name', String),
+                       Column('email', String),
+                       UniqueConstraint('email'))
+
+order_table = Table('order', meta,
+                    Column('id', Integer, primary_key=True),
+                    Column('customer_id', Integer, ForeignKey('customer.id')),
+                    Column('info', String),
+                    Column('status', String, CheckConstraint("status in ('open', 'closed')")))
+
+
+class IntrospectionTest(fixtures.TestBase):
+    def teardown_method(self, method):
+        meta.drop_all(testing.db)
+
+    def setup_method(self):
+        meta.create_all(testing.db)
+
+    def test_create_metadata(self):
+        # Create a metadata via introspection on the live DB.
+        meta2 = MetaData(testing.db)
+
+        # TODO(bdarnell): Do more testing.
+        # For now just make sure it doesn't raise exceptions.
+        # This covers get_foreign_keys(), which is apparently untested
+        # in SQLAlchemy's dialect test suite.
+        Table('customer', meta2, autoload=True)
+        Table('order', meta2, autoload=True)


### PR DESCRIPTION
Works around an exception when using `Table(autoload=True)`

Updates #27