### PR TITLE
Fixes issues with NULLTYPE not being callable

### DIFF
--- a/cockroachdb/sqlalchemy/dialect.py
+++ b/cockroachdb/sqlalchemy/dialect.py
@@ -106,7 +106,7 @@ class CockroachDBDialect(PGDialect_psycopg2):
             m = re.match(r'^(\w+)(?:\(([0-9, ]*)\))?$', type_str)
             if m is None:
                 warn("Could not parse type name '%s'" % type_str)
-                typ = sqltypes.NULLTYPE()
+                typ = sqltypes.NULLTYPE
             else:
                 type_name, type_args = m.groups()
                 try:
@@ -118,7 +118,7 @@ class CockroachDBDialect(PGDialect_psycopg2):
                 if type_args:
                     typ = type_class(*[int(s.strip()) for s in type_args.split(',')])
                 else:
-                    typ = type_class()
+                    typ = type_class
             res.append(dict(
                 name=name,
                 type=typ,

--- a/cockroachdb/sqlalchemy/dialect.py
+++ b/cockroachdb/sqlalchemy/dialect.py
@@ -16,7 +16,7 @@ from .stmt_compiler import CockroachCompiler
 # TODO(bdarnell): test more of these. The stock test suite only covers
 # a few basic ones.
 _type_map = dict(
-    boolean=sqltypes.BOOLEAN,
+    bool=sqltypes.BOOLEAN,
     int=sqltypes.INT,
     integer=sqltypes.INT,
     smallint=sqltypes.INT,


### PR DESCRIPTION
This fixes some issues with non-callable fields but then fails to continue due to inability to parse the boolean and timestamp type from table columns:

```
/.../cockroachdb/sqlalchemy/dialect.py:108: SAWarning: Could not parse type name 'TIMESTAMP WITH TIME ZONE'
  warn("Could not parse type name '%s'" % type_str)
/.../cockroachdb/sqlalchemy/dialect.py:116: SAWarning: Did not recognize type 'BOOL' of column 'is_current'
  (type_name, name))
/.../cockroachdb/sqlalchemy/dialect.py:116: SAWarning: Did not recognize type 'BOOL' of column 'qr_tested'
  (type_name, name))
/.../cockroachdb/sqlalchemy/dialect.py:116: SAWarning: Did not recognize type 'BOOL' of column 'imports_approved'
  (type_name, name))
```

