### PR TITLE
Register an alembic dialect

### DIFF
--- a/cockroachdb/sqlalchemy/dialect.py
+++ b/cockroachdb/sqlalchemy/dialect.py
@@ -200,3 +200,13 @@ class CockroachDBDialect(PGDialect_psycopg2):
             connection.execute('RELEASE SAVEPOINT cockroach_restart')
         else:
             super(CockroachDBDialect, self).do_release_savepoint(connection, name)
+
+
+# If alembic is installed, register an alias in its dialect mapping too.
+try:
+    import alembic.ddl.postgresql
+except ImportError:
+    pass
+else:
+    class CockroachDBImpl(alembic.ddl.postgresql.PostgresqlImpl):
+        __dialect__ = 'cockroachdb'

--- a/cockroachdb/sqlalchemy/dialect.py
+++ b/cockroachdb/sqlalchemy/dialect.py
@@ -202,7 +202,7 @@ class CockroachDBDialect(PGDialect_psycopg2):
             super(CockroachDBDialect, self).do_release_savepoint(connection, name)
 
 
-# If alembic is installed, register an alias in its dialect mapping too.
+# If alembic is installed, register an alias in its dialect mapping.
 try:
     import alembic.ddl.postgresql
 except ImportError:
@@ -210,3 +210,12 @@ except ImportError:
 else:
     class CockroachDBImpl(alembic.ddl.postgresql.PostgresqlImpl):
         __dialect__ = 'cockroachdb'
+
+
+# If sqlalchemy-migrate is installed, register there too.
+try:
+    from migrate.changeset.databases.visitor import DIALECTS as migrate_dialects
+except ImportError:
+    pass
+else:
+    migrate_dialects['cockroachdb'] = migrate_dialects['postgresql']


### PR DESCRIPTION
Alembic is the migration add-on for SQLAlchemy with its own dialect
system. Detect the presence of this package and register a dialect
(currently just an alias for the postgres dialect).

Alembic's test suite is not cleanly factored for us to reuse, but in
manual testing it appears to work except for two issues:
- For tables without a primary key, we create a hidden `rowid` column.
  But it's apparently not hidden enough; alembic sees it and gets
  confused. This appears to affect a lot of alembic's tests so I'm not
  sure how much coverage we're actually getting here.
- We don't yet support ON DELETE or ON UPDATE clauses for foreign keys.