### PR TITLE
Add `bool` type as an alias to Boolean

### DIFF
--- a/cockroachdb/sqlalchemy/dialect.py
+++ b/cockroachdb/sqlalchemy/dialect.py
@@ -15,6 +15,7 @@ from .stmt_compiler import CockroachCompiler
 # TODO(bdarnell): test more of these. The stock test suite only covers
 # a few basic ones.
 _type_map = dict(
+    bool=sqltypes.BOOLEAN,  # introspection returns "BOOL" not boolean
     boolean=sqltypes.BOOLEAN,
     int=sqltypes.INT,
     integer=sqltypes.INT,

--- a/test/sqlalchemy/test_introspection.py
+++ b/test/sqlalchemy/test_introspection.py
@@ -1,6 +1,6 @@
 from sqlalchemy import Table, Column, MetaData, testing, ForeignKey, UniqueConstraint, \
     CheckConstraint
-from sqlalchemy.types import Integer, String
+from sqlalchemy.types import Integer, String, Boolean
 from sqlalchemy.testing import fixtures
 
 meta = MetaData()
@@ -9,6 +9,7 @@ customer_table = Table('customer', meta,
                        Column('id', Integer, primary_key=True),
                        Column('name', String),
                        Column('email', String),
+                       Column('verified', Boolean),
                        UniqueConstraint('email'))
 
 order_table = Table('order', meta,


### PR DESCRIPTION
This helps solving the following introspection problem:
```
/usr/local/lib/python3.5/dist-packages/cockroachdb/sqlalchemy/dialect.py:115: SAWarning: Did not recognize type 'BOOL' of column 'is_something_happened'
  (type_name, name))
```
And the subsequent error:
```
  File "/usr/local/lib/python3.5/dist-packages/alembic/autogenerate/compare.py", line 48, in _produce_net_changes                      [48/1946]
    autogen_context, upgrade_ops, schemas
  File "/usr/local/lib/python3.5/dist-packages/alembic/util/langhelpers.py", line 313, in go
    fn(*arg, **kw)
  File "/usr/local/lib/python3.5/dist-packages/alembic/autogenerate/compare.py", line 75, in _autogen_for_tables
    inspector, upgrade_ops, autogen_context)
  File "/usr/local/lib/python3.5/dist-packages/alembic/autogenerate/compare.py", line 137, in _compare_tables
    inspector.reflecttable(t, None)
  File "/usr/local/lib/python3.5/dist-packages/sqlalchemy/engine/reflection.py", line 598, in reflecttable
    table_name, schema, **table.dialect_kwargs):
  File "/usr/local/lib/python3.5/dist-packages/sqlalchemy/engine/reflection.py", line 369, in get_columns
    **kw)
  File "/usr/local/lib/python3.5/dist-packages/cockroachdb/sqlalchemy/dialect.py", line 120, in get_columns
    typ = type_class()
TypeError: 'NullType' object is not callable
```
This uses alembic, but I think the core problem is introspection not alembic per se.

Versions:
* python bindings 0.1.1
* cocroachb itself 1.1.2