### PR TITLE
cockroachdb.sqlalchemy.dialect: Add JSON and JSONB to type map

### DIFF
--- a/cockroachdb/sqlalchemy/dialect.py
+++ b/cockroachdb/sqlalchemy/dialect.py
@@ -35,6 +35,8 @@ _type_map = dict(
     varchar=sqltypes.VARCHAR,
     bytes=sqltypes.BLOB,
     blob=sqltypes.BLOB,
+    json=sqltypes.JSON,
+    jsonb=sqltypes.JSON,
 )
 
 


### PR DESCRIPTION
Fixes the following error I was getting when trying to add a flask-migrate/Alembic migration with a table that uses the `JSON` type:

```
INFO  [alembic.runtime.migration] Context impl CockroachDBImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
/venv/lib/python3.5/site-packages/cockroachdb/sqlalchemy/dialect.py:118: SAWarning: Did not recognize type 'JSON' of column 'json'
  (type_name, name))
Traceback (most recent call last):
  File "/venv/bin/flask", line 11, in <module>
    sys.exit(main())
  File "/venv/lib/python3.5/site-packages/flask/cli.py", line 894, in main
    cli.main(args=args, prog_name=name)
  File "/venv/lib/python3.5/site-packages/flask/cli.py", line 557, in main
    return super(FlaskGroup, self).main(*args, **kwargs)
  File "/venv/lib/python3.5/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/venv/lib/python3.5/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/venv/lib/python3.5/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/venv/lib/python3.5/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/venv/lib/python3.5/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/venv/lib/python3.5/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/venv/lib/python3.5/site-packages/flask/cli.py", line 412, in decorator
    return __ctx.invoke(f, *args, **kwargs)
  File "/venv/lib/python3.5/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/venv/lib/python3.5/site-packages/flask_migrate/cli.py", line 90, in migrate
    rev_id, x_arg)
  File "/venv/lib/python3.5/site-packages/flask_migrate/__init__.py", line 197, in migrate
    version_path=version_path, rev_id=rev_id)
  File "/venv/lib/python3.5/site-packages/alembic/command.py", line 176, in revision
    script_directory.run_env()
  File "/venv/lib/python3.5/site-packages/alembic/script/base.py", line 427, in run_env
    util.load_python_file(self.dir, 'env.py')
  File "/venv/lib/python3.5/site-packages/alembic/util/pyfiles.py", line 81, in load_python_file
    module = load_module_py(module_id, path)
  File "/venv/lib/python3.5/site-packages/alembic/util/compat.py", line 83, in load_module_py
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 697, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/code/hotpotato/migrations/env.py", line 97, in <module>
    run_migrations_online()
  File "/code/hotpotato/migrations/env.py", line 89, in run_migrations_online
    context.run_migrations()
  File "<string>", line 8, in run_migrations
  File "/venv/lib/python3.5/site-packages/alembic/runtime/environment.py", line 836, in run_migrations
    self.get_context().run_migrations(**kw)
  File "/venv/lib/python3.5/site-packages/alembic/runtime/migration.py", line 321, in run_migrations
    for step in self._migrations_fn(heads, self):
  File "/venv/lib/python3.5/site-packages/alembic/command.py", line 156, in retrieve_migrations
    revision_context.run_autogenerate(rev, context)
  File "/venv/lib/python3.5/site-packages/alembic/autogenerate/api.py", line 415, in run_autogenerate
    self._run_environment(rev, migration_context, True)
  File "/venv/lib/python3.5/site-packages/alembic/autogenerate/api.py", line 451, in _run_environment
    autogen_context, migration_script)
  File "/venv/lib/python3.5/site-packages/alembic/autogenerate/compare.py", line 22, in _populate_migration_script
    _produce_net_changes(autogen_context, upgrade_ops)
  File "/venv/lib/python3.5/site-packages/alembic/autogenerate/compare.py", line 48, in _produce_net_changes
    autogen_context, upgrade_ops, schemas
  File "/venv/lib/python3.5/site-packages/alembic/util/langhelpers.py", line 313, in go
    fn(*arg, **kw)
  File "/venv/lib/python3.5/site-packages/alembic/autogenerate/compare.py", line 75, in _autogen_for_tables
    inspector, upgrade_ops, autogen_context)
  File "/venv/lib/python3.5/site-packages/alembic/autogenerate/compare.py", line 168, in _compare_tables
    inspector.reflecttable(t, None)
  File "/venv/lib/python3.5/site-packages/sqlalchemy/engine/reflection.py", line 618, in reflecttable
    table_name, schema, **table.dialect_kwargs):
  File "/venv/lib/python3.5/site-packages/sqlalchemy/engine/reflection.py", line 369, in get_columns
    **kw)
  File "/venv/lib/python3.5/site-packages/cockroachdb/sqlalchemy/dialect.py", line 123, in get_columns
    typ = type_class()
TypeError: 'NullType' object is not callable
```