### PR TITLE
Disable transactional DDL in alembic

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+# Version 0.2.1
+
+Released Aug 16, 2018
+
+- Alembic migrations no longer attempt to run DDL statements in transactions.
+- Comments are now dropped from table definitions as CockroachDB does not support them.
+
 # Version 0.2.0
 
 Released July 16, 2018

--- a/cockroachdb/sqlalchemy/dialect.py
+++ b/cockroachdb/sqlalchemy/dialect.py
@@ -398,6 +398,7 @@ except ImportError:
 else:
     class CockroachDBImpl(alembic.ddl.postgresql.PostgresqlImpl):
         __dialect__ = 'cockroachdb'
+        transactional_ddl = False
 
 
 # If sqlalchemy-migrate is installed, register there too.

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ install_requires = [
 
 setup(
     name='cockroachdb',
-    version='0.2.0',
+    version='0.2.1',
     author='Cockroach Labs',
     author_email='cockroach-db@googlegroups.com',
     url='https://github.com/cockroachdb/cockroachdb-python',


### PR DESCRIPTION
Our support for DDL in transactions is limited, so we're better off
not trying.