### PR TITLE
Add more types to mapping dictionary

### DIFF
--- a/build/circle-deps.sh
+++ b/build/circle-deps.sh
@@ -15,7 +15,7 @@ case $OSTYPE in
     *) echo "Unsupported platform"; exit 1;;
 esac
 
-for COCKROACH_VERSION in v2.1.0-alpha.20180730; do
+for COCKROACH_VERSION in v2.1.3; do
   COCKROACH_NAME=cockroach-${COCKROACH_VERSION}.${COCKROACH_PLATFORM}
   DOWNLOAD_DIR=~/cockroach-download
 

--- a/build/circle-test.sh
+++ b/build/circle-test.sh
@@ -4,14 +4,10 @@ set -eux -o pipefail
 
 source env/bin/activate
 
-# TODO(bdarnell): versions 2.0 and 1.1 currently fail because of the
-# LIKE ESCAPE operator, and we don't have a clean way to disable that
-# part of the test suite.
-
-for version in v2.1; do
+for executable in env/bin/cockroach-*; do
   rm -rf cockroach-data
-  "cockroach-$version" start --background --insecure --pid-file=cockroach.pid
-  "cockroach-$version" sql --insecure -e 'CREATE DATABASE IF NOT EXISTS test_sqlalchemy'
+  ${executable} start --background --insecure --pid-file=cockroach.pid
+  ${executable} sql --insecure -e 'CREATE DATABASE IF NOT EXISTS test_sqlalchemy'
 
   make test
   kill -9 $(cat cockroach.pid)

--- a/cockroachdb/sqlalchemy/dialect.py
+++ b/cockroachdb/sqlalchemy/dialect.py
@@ -157,7 +157,7 @@ class CockroachDBDialect(PGDialect_psycopg2):
             rows = conn.execute('''
         SELECT column_name, data_type, is_nullable::bool, column_default
         FROM information_schema.columns
-        WHERE table_schema = %s AND table_name = %s''',
+        WHERE table_schema = %s AND table_name = %s AND NOT is_hidden::bool''',
                                 (schema or self.default_schema_name, table_name))
 
         res = []

--- a/cockroachdb/sqlalchemy/dialect.py
+++ b/cockroachdb/sqlalchemy/dialect.py
@@ -3,6 +3,8 @@ import re
 import threading
 from sqlalchemy.dialects.postgresql.base import PGDialect
 from sqlalchemy.dialects.postgresql.psycopg2 import PGDialect_psycopg2
+from sqlalchemy.dialects.postgresql import INET
+from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.util import warn
 import sqlalchemy.sql as sql
 
@@ -18,26 +20,56 @@ from .stmt_compiler import CockroachCompiler, CockroachIdentifierPreparer
 _type_map = {
     'bool': sqltypes.BOOLEAN,  # introspection returns "BOOL" not boolean
     'boolean': sqltypes.BOOLEAN,
+
+    'bigint': sqltypes.INT,
     'int': sqltypes.INT,
+    'int2': sqltypes.INT,
+    'int4': sqltypes.INT,
+    'int64': sqltypes.INT,
+    'int8': sqltypes.INT,
     'integer': sqltypes.INT,
     'smallint': sqltypes.INT,
-    'bigint': sqltypes.INT,
+
+    'double precision': sqltypes.FLOAT,
     'float': sqltypes.FLOAT,
+    'float4': sqltypes.FLOAT,
+    'float8': sqltypes.FLOAT,
     'real': sqltypes.FLOAT,
-    'double': sqltypes.FLOAT,
+
+    'dec': sqltypes.DECIMAL,
     'decimal': sqltypes.DECIMAL,
     'numeric': sqltypes.DECIMAL,
+
     'date': sqltypes.DATE,
+
+    'time': sqltypes.Time,
+    'time without time zone': sqltypes.Time,
+
     'timestamp': sqltypes.TIMESTAMP,
     'timestamptz': sqltypes.TIMESTAMP,
+    'timestamp with time zone': sqltypes.TIMESTAMP,
+    'timestamp without time zone': sqltypes.TIMESTAMP,
+
     'interval': sqltypes.Interval,
-    'string': sqltypes.VARCHAR,
+
     'char': sqltypes.VARCHAR,
+    'char varying': sqltypes.VARCHAR,
+    'character': sqltypes.VARCHAR,
+    'character varying': sqltypes.VARCHAR,
+    'string': sqltypes.VARCHAR,
+    'text': sqltypes.Text,
     'varchar': sqltypes.VARCHAR,
-    'bytes': sqltypes.BLOB,
+
     'blob': sqltypes.BLOB,
+    'bytea': sqltypes.BLOB,
+    'bytes': sqltypes.BLOB,
+
     'json': sqltypes.JSON,
     'jsonb': sqltypes.JSON,
+
+    'uuid': UUID,
+
+    'inet': INET,
 }
 
 

--- a/cockroachdb/sqlalchemy/dialect.py
+++ b/cockroachdb/sqlalchemy/dialect.py
@@ -15,30 +15,30 @@ from .stmt_compiler import CockroachCompiler, CockroachIdentifierPreparer
 #
 # TODO(bdarnell): test more of these. The stock test suite only covers
 # a few basic ones.
-_type_map = dict(
-    bool=sqltypes.BOOLEAN,  # introspection returns "BOOL" not boolean
-    boolean=sqltypes.BOOLEAN,
-    int=sqltypes.INT,
-    integer=sqltypes.INT,
-    smallint=sqltypes.INT,
-    bigint=sqltypes.INT,
-    float=sqltypes.FLOAT,
-    real=sqltypes.FLOAT,
-    double=sqltypes.FLOAT,
-    decimal=sqltypes.DECIMAL,
-    numeric=sqltypes.DECIMAL,
-    date=sqltypes.DATE,
-    timestamp=sqltypes.TIMESTAMP,
-    timestamptz=sqltypes.TIMESTAMP,
-    interval=sqltypes.Interval,
-    string=sqltypes.VARCHAR,
-    char=sqltypes.VARCHAR,
-    varchar=sqltypes.VARCHAR,
-    bytes=sqltypes.BLOB,
-    blob=sqltypes.BLOB,
-    json=sqltypes.JSON,
-    jsonb=sqltypes.JSON,
-)
+_type_map = {
+    'bool': sqltypes.BOOLEAN,  # introspection returns "BOOL" not boolean
+    'boolean': sqltypes.BOOLEAN,
+    'int': sqltypes.INT,
+    'integer': sqltypes.INT,
+    'smallint': sqltypes.INT,
+    'bigint': sqltypes.INT,
+    'float': sqltypes.FLOAT,
+    'real': sqltypes.FLOAT,
+    'double': sqltypes.FLOAT,
+    'decimal': sqltypes.DECIMAL,
+    'numeric': sqltypes.DECIMAL,
+    'date': sqltypes.DATE,
+    'timestamp': sqltypes.TIMESTAMP,
+    'timestamptz': sqltypes.TIMESTAMP,
+    'interval': sqltypes.Interval,
+    'string': sqltypes.VARCHAR,
+    'char': sqltypes.VARCHAR,
+    'varchar': sqltypes.VARCHAR,
+    'bytes': sqltypes.BLOB,
+    'blob': sqltypes.BLOB,
+    'json': sqltypes.JSON,
+    'jsonb': sqltypes.JSON,
+}
 
 
 class _SavepointState(threading.local):

--- a/cockroachdb/sqlalchemy/dialect.py
+++ b/cockroachdb/sqlalchemy/dialect.py
@@ -156,7 +156,7 @@ class CockroachDBDialect(PGDialect_psycopg2):
             # v2.0 or later. Information schema is usable.
             rows = conn.execute(
                 'SELECT column_name, data_type, is_nullable::bool, column_default, '
-                'numeric_precision, numeric_scale '
+                'numeric_precision, numeric_scale, character_maximum_length '
                 'FROM information_schema.columns '
                 'WHERE table_schema = %s AND table_name = %s AND NOT is_hidden::bool',
                 (schema or self.default_schema_name, table_name),
@@ -186,6 +186,8 @@ class CockroachDBDialect(PGDialect_psycopg2):
                         precision=row.numeric_precision,
                         scale=row.numeric_scale,
                     )
+                elif type_class is sqltypes.VARCHAR:
+                    typ = type_class(length=row.character_maximum_length)
                 else:
                     typ = type_class()
             res.append(dict(

--- a/cockroachdb/sqlalchemy/dialect.py
+++ b/cockroachdb/sqlalchemy/dialect.py
@@ -133,7 +133,7 @@ class CockroachDBDialect(PGDialect_psycopg2):
             name, type_str, nullable, default = row[:4]
             # When there are type parameters, attach them to the
             # returned type object.
-            m = re.match(r'^(\w+)(?:\(([0-9, ]*)\))?$', type_str)
+            m = re.match(r'^(\w+(?: \w+)*)(?:\(([0-9, ]*)\))?$', type_str)
             if m is None:
                 warn("Could not parse type name '%s'" % type_str)
                 typ = sqltypes.NULLTYPE()

--- a/cockroachdb/sqlalchemy/dialect.py
+++ b/cockroachdb/sqlalchemy/dialect.py
@@ -114,7 +114,6 @@ class CockroachDBDialect(PGDialect_psycopg2):
         self.supports_native_enum = False
         self.supports_smallserial = False
         self._backslash_escapes = False
-        self._has_native_jsonb = True
         sversion = connection.scalar("select version()")
         self._is_v2plus = " v2." in sversion
         self._is_v21plus = self._is_v2plus and (" v2.0." not in sversion)

--- a/cockroachdb/sqlalchemy/dialect.py
+++ b/cockroachdb/sqlalchemy/dialect.py
@@ -57,7 +57,7 @@ _type_map = {
     'character': sqltypes.VARCHAR,
     'character varying': sqltypes.VARCHAR,
     'string': sqltypes.VARCHAR,
-    'text': sqltypes.Text,
+    'text': sqltypes.VARCHAR,
     'varchar': sqltypes.VARCHAR,
 
     'blob': sqltypes.BLOB,

--- a/cockroachdb/sqlalchemy/test_requirements.py
+++ b/cockroachdb/sqlalchemy/test_requirements.py
@@ -75,7 +75,3 @@ class Requirements(SuiteRequirements):
     order_by_label_with_expression = exclusions.open()
     order_by_col_from_union = exclusions.open()
     implicitly_named_constraints = exclusions.open()
-
-    # Mostly work, except for https://github.com/cockroachdb/cockroach/issues/28548
-    index_reflection = exclusions.closed()
-    unique_constraint_reflection = exclusions.closed()


### PR DESCRIPTION
This PR adds more types to the mapping dictionary (See [cockroach docs](https://www.cockroachlabs.com/docs/v2.1/data-types.html)). It will probably fix #73, fix #63 and fix #60.

Additional note:
I was unsure how to add the `ARRAY`.