### PR TITLE
Add type reflection tests

### DIFF
--- a/test/sqlalchemy/test_introspection.py
+++ b/test/sqlalchemy/test_introspection.py
@@ -1,7 +1,10 @@
 from sqlalchemy import Table, Column, MetaData, testing, ForeignKey, UniqueConstraint, \
     CheckConstraint
 from sqlalchemy.types import Integer, String, Boolean
+import sqlalchemy.types as sqltypes
 from sqlalchemy.testing import fixtures
+from sqlalchemy.dialects.postgresql import INET
+from sqlalchemy.dialects.postgresql import UUID
 
 meta = MetaData()
 
@@ -44,3 +47,85 @@ class IntrospectionTest(fixtures.TestBase):
         Table('order', meta2, autoload=True)
         Table('index', meta2, autoload=True)
         Table('view', meta2, autoload=True)
+
+
+class TestTypeReflection(fixtures.TestBase):
+    TABLE_NAME = 't'
+    COLUMN_NAME = 'c'
+
+    @testing.provide_metadata
+    def _test(self, typ, expected):
+        testing.db.execute(
+            'CREATE TABLE {} ({} {})'.format(
+                self.TABLE_NAME,
+                self.COLUMN_NAME,
+                typ,
+            )
+        )
+
+        t = Table(self.TABLE_NAME, self.metadata, autoload=True)
+        c = t.c[self.COLUMN_NAME]
+        assert isinstance(c.type, expected)
+
+    def test_boolean(self):
+        for t in ['bool', 'boolean']:
+            self._test(t, sqltypes.BOOLEAN)
+
+    def test_int(self):
+        for t in ['bigint', 'int', 'int2', 'int4', 'int64', 'int8', 'integer', 'smallint']:
+            self._test(t, sqltypes.INT)
+
+    def test_float(self):
+        for t in ['double precision', 'float', 'float4', 'float8', 'real']:
+            self._test(t, sqltypes.FLOAT)
+
+    def test_decimal(self):
+        for t in ['dec', 'decimal', 'numeric']:
+            self._test(t, sqltypes.DECIMAL)
+
+    def test_date(self):
+        self._test('date', sqltypes.DATE)
+
+    def test_time(self):
+        for t in ['time', 'time without time zone']:
+            self._test(t, sqltypes.Time)
+
+    def test_timestamp(self):
+        types = [
+            'timestamp',
+            'timestamptz',
+            'timestamp with time zone',
+            'timestamp without time zone',
+        ]
+        for t in types:
+            self._test(t, sqltypes.TIMESTAMP)
+
+    def test_interval(self):
+        self._test('interval', sqltypes.Interval)
+
+    def test_varchar(self):
+        types = [
+            'char',
+            'char varying',
+            'character',
+            'character varying',
+            'string',
+            'text',
+            'varchar',
+        ]
+        for t in types:
+            self._test(t, sqltypes.VARCHAR)
+
+    def test_blob(self):
+        for t in ['blob', 'bytea', 'bytes']:
+            self._test(t, sqltypes.BLOB)
+
+    def test_json(self):
+        for t in ['json', 'jsonb']:
+            self._test(t, sqltypes.JSON)
+
+    def test_uuid(self):
+        self._test('uuid', UUID)
+
+    def test_inet(self):
+        self._test('inet', INET)


### PR DESCRIPTION
This PR adds tests for #74 

I couldn't use the *normal* pytest parametrization (`pytest.mark.parametrize`) and fixtures because it somehow interfered with the [ sqlalchemy plugin](https://github.com/cockroachdb/cockroachdb-python/blob/4650bb08203563af90e97b3a28f3d7e8a253e6bd/tox.ini#L8). That's basically the cause why I switched to the `for t in [...]` loop construct. 