### PR TITLE
Fix handling of unknown types

### DIFF
--- a/cockroachdb/sqlalchemy/dialect.py
+++ b/cockroachdb/sqlalchemy/dialect.py
@@ -172,7 +172,7 @@ class CockroachDBDialect(PGDialect_psycopg2):
             m = re.match(r'^(\w+(?: \w+)*)(?:\(([0-9, ]*)\))?$', type_str)
             if m is None:
                 warn("Could not parse type name '%s'" % type_str)
-                typ = sqltypes.NULLTYPE()
+                typ = sqltypes.NULLTYPE
             else:
                 type_name, type_args = m.groups()
                 try:

--- a/cockroachdb/sqlalchemy/dialect.py
+++ b/cockroachdb/sqlalchemy/dialect.py
@@ -191,7 +191,7 @@ class CockroachDBDialect(PGDialect_psycopg2):
                 elif type_class is sqltypes.VARCHAR:
                     typ = type_class(length=row.character_maximum_length)
                 else:
-                    typ = type_class()
+                    typ = type_class
             res.append(dict(
                 name=name,
                 type=typ,

--- a/test/sqlalchemy/test_introspection.py
+++ b/test/sqlalchemy/test_introspection.py
@@ -1,4 +1,3 @@
-import warnings
 import pytest
 import contextlib
 
@@ -133,6 +132,7 @@ class TestTypeReflection(fixtures.TestBase):
 
     def test_inet(self):
         self._test('inet', INET)
+
 
 class UnknownTypeTest(fixtures.TestBase):
     def setup_method(self):


### PR DESCRIPTION
When the dialect encounters an unknown type it tries to instantiate
NULLTYPE which is not callable. This removes that and correctly passes
it as a sentinel value.

Essentially an updated version of #31