### PR TITLE
Fix potential kwargs conflicts

### DIFF
--- a/cockroachdb/sqlalchemy/dialect.py
+++ b/cockroachdb/sqlalchemy/dialect.py
@@ -98,10 +98,13 @@ class CockroachDBDialect(PGDialect_psycopg2):
     preparer = CockroachIdentifierPreparer
 
     def __init__(self, *args, **kwargs):
-        super(CockroachDBDialect, self).__init__(*args,
-                                                 use_native_hstore=False,
-                                                 server_side_cursors=False,
-                                                 **kwargs)
+        if kwargs.get("use_native_hstore", False):
+            raise NotImplementedError("use_native_hstore is not supported")
+        if kwargs.get("server_side_cursors", False):
+            raise NotImplementedError("server_side_cursors is not supported")
+        kwargs["use_native_hstore"] = False
+        kwargs["server_side_cursors"] = False
+        super(CockroachDBDialect, self).__init__(*args, **kwargs)
 
     def initialize(self, connection):
         # Bypass PGDialect's initialize implementation, which looks at


### PR DESCRIPTION
Our SQLAlchemy dialect constructor was erroring out with a "got multiple
values for keyword argument" error if the use_native_hstore or
server_side_cursors keyword arguments were passed in. This is because we
were already explicitly setting them to False. I updated the logic to
fail with a more helpful NotImplementedError if True is passed in for
these args and to not error out otherwise.

This came up when running the test/dialect/test_suite.py SQLAlchemy
tests against Cockroach.