### PR TITLE
Stop using deprecated sql.text.typemap parameter

### DIFF
--- a/cockroachdb/sqlalchemy/dialect.py
+++ b/cockroachdb/sqlalchemy/dialect.py
@@ -314,9 +314,8 @@ class CockroachDBDialect(PGDialect_psycopg2):
             r'[\s]?(INITIALLY (DEFERRED|IMMEDIATE)+)?'
         )
 
-        t = sql.text(FK_SQL, typemap={
-            'conname': sqltypes.Unicode,
-            'condef': sqltypes.Unicode})
+        t = sql.text(FK_SQL).columns(conname=sqltypes.Unicode,
+                                     condef=sqltypes.Unicode)
         c = connection.execute(t, table=table_oid)
         fkeys = []
         for conname, condef, conschema in c.fetchall():


### PR DESCRIPTION
Updated get_foreign_keys() to use the sql.TextClause.columns method
rather than the deprecated typemap parameter.

Fixes #93