### PR TITLE
add psycopg2 requirement for cockroachdb-python

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,35 +4,40 @@
 # generated dev-requirements.txt), run make update-requirements,
 # then re-run bootstrap.sh.
 
-flake8==3.7.7
-tox==3.13.1
+flake8==3.7.9
+psycopg2==2.8.4
+SQLAlchemy==1.3.15
+tox==3.14.5
 # Twine is used in the release process to upload the package.
-twine==1.13.0
+twine==3.1.1
 ## The following requirements were added by pip freeze:
-bleach==3.1.0
-certifi==2019.6.16
+appdirs==1.4.3
+bleach==3.1.3
+certifi==2019.11.28
 chardet==3.0.4
-docutils==0.14
+distlib==0.3.0
+docutils==0.16
 entrypoints==0.3
 filelock==3.0.12
-idna==2.8
-importlib-metadata==0.18
+idna==2.9
+importlib-metadata==1.5.0
+keyring==21.2.0
 mccabe==0.6.1
-packaging==19.0
+packaging==20.3
 pkginfo==1.5.0.1
-pluggy==0.12.0
-py==1.8.0
+pluggy==0.13.1
+py==1.8.1
 pycodestyle==2.5.0
 pyflakes==2.1.1
-Pygments==2.4.2
-pyparsing==2.4.0
-readme-renderer==24.0
-requests==2.22.0
+Pygments==2.6.1
+pyparsing==2.4.6
+readme-renderer==25.0
+requests==2.23.0
 requests-toolbelt==0.9.1
-six==1.12.0
+six==1.14.0
 toml==0.10.0
-tqdm==4.32.2
-urllib3==1.25.3
-virtualenv==16.6.1
+tqdm==4.43.0
+urllib3==1.25.8
+virtualenv==20.0.10
 webencodings==0.5.1
-zipp==0.5.1
+zipp==3.1.0

--- a/dev-requirements.txt.in
+++ b/dev-requirements.txt.in
@@ -5,6 +5,8 @@
 # then re-run bootstrap.sh.
 
 flake8
+psycopg2
+SQLAlchemy
 tox
 
 # Twine is used in the release process to upload the package.

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,9 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
-        ],
+    ],
 
+    install_requires=['psycopg2', 'SQLAlchemy'],
     packages=['cockroachdb', 'cockroachdb.sqlalchemy'],
     entry_points={
         'sqlalchemy.dialects': [


### PR DESCRIPTION
I was following the instructions at https://www.cockroachlabs.com/docs/v20.1/build-a-python-app-with-cockroachdb-sqlalchemy.html, but after doing `pip install sqlalchemy cockroachdb` I found that `psycopg2` is required. I could update the docs, but I think a cleaner solution would be to force it to be included in setup.py.

Also did some spring cleaning of the requirements.